### PR TITLE
Add sorting to media.

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -18,7 +18,12 @@ def lambda_handler(event, context):
                 omeka_data[text['element']['name']] = text['text']
             if item['files']['count'] > 0:
                 files = requests.get(item['files']['url'])
-                media = [{'urls': f['file_urls']} for f in files.json()]
+                media = sorted(
+                    [{'urls': f['file_urls'], 'order': f['order']} for f in files.json()],
+                    key= lambda i: i['order'] if i['order'] else 100000
+                )
+                for m in media:
+                    del m['order']
             else:
                 media = []
             finds.append({'id': str(idx), 'omekaData': omeka_data, 'media': media})


### PR DESCRIPTION
Make sure media urls are sorted according to order.

Seemed like the best option to initially pull in the `order` attribute, sort on it if it is defined, and then delete it.

From this point, `media` is a List, which should maintain its order.

This makes it so that `hyap-trenches` does not need to be updated in how it ingests the data.